### PR TITLE
Fix range selection

### DIFF
--- a/CommunityToolkit.WinUI.UI.Controls.DataGrid/CommunityToolkit.WinUI.UI.Controls.DataGrid.csproj
+++ b/CommunityToolkit.WinUI.UI.Controls.DataGrid/CommunityToolkit.WinUI.UI.Controls.DataGrid.csproj
@@ -29,5 +29,5 @@
   </ItemGroup>
 
   <Import Project="$(BuildToolsDirectory)Windows.Toolkit.WinUI.Controls.targets" />
-
+  
 </Project>

--- a/CommunityToolkit.WinUI.UI.Controls.DataGrid/DataGrid/DataGridEnumerations.cs
+++ b/CommunityToolkit.WinUI.UI.Controls.DataGrid/DataGrid/DataGridEnumerations.cs
@@ -153,7 +153,9 @@ namespace CommunityToolkit.WinUI.UI.Controls
         None,
         RemoveCurrentFromSelection,
         SelectCurrent,
-        SelectFromAnchorToCurrent
+        SelectFromAnchorToCurrent,
+        AddRangeToSelection,
+        RemoveRangeFromSelection
     }
 
     /// <summary>

--- a/CommunityToolkit.WinUI.UI.Controls.DataGrid/DataGrid/DataGridRows.cs
+++ b/CommunityToolkit.WinUI.UI.Controls.DataGrid/DataGrid/DataGridRows.cs
@@ -759,7 +759,6 @@ namespace CommunityToolkit.WinUI.UI.Controls
 
         internal void SetRowSelection(int slot, bool isSelected, bool setAnchorSlot)
         {
-            DiagnosticsDebug.Assert(isSelected || !setAnchorSlot, "Expected isSelected is true or setAnchorSlot is false.");
             DiagnosticsDebug.Assert(!IsSlotOutOfSelectionBounds(slot), "Expected IsSlotOutOfSelectionBounds(slot) is false.");
             _noSelectionChangeCount++;
             try
@@ -795,7 +794,6 @@ namespace CommunityToolkit.WinUI.UI.Controls
             }
         }
 
-        // For now, all scenarios are for isSelected == true.
         internal void SetRowsSelection(int startSlot, int endSlot, bool isSelected = true)
         {
             DiagnosticsDebug.Assert(startSlot >= 0, "Expected startSlot is positive.");
@@ -811,6 +809,13 @@ namespace CommunityToolkit.WinUI.UI.Controls
                 {
                     // At least one row gets selected
                     SelectSlots(startSlot, endSlot, true);
+                    this.SelectionHasChanged = true;
+                }
+
+                if (!isSelected && _selectedItems.ContainsAny(startSlot, endSlot))
+                {
+                    // At least one row gets deselected
+                    SelectSlots(startSlot, endSlot, false);
                     this.SelectionHasChanged = true;
                 }
             }

--- a/CommunityToolkit.WinUI.UI.Controls.DataGrid/Utilities/IndexToValueTable.cs
+++ b/CommunityToolkit.WinUI.UI.Controls.DataGrid/Utilities/IndexToValueTable.cs
@@ -149,6 +149,25 @@ namespace CommunityToolkit.WinUI.Utilities
         }
 
         /// <summary>
+        /// Returns true if any index from the range is contained in the table
+        /// </summary>
+        /// <param name="startIndex">beginning of the range</param>
+        /// <param name="endIndex">end of the range</param>
+        /// <returns>True if any of the indexes in the index range is present in the table</returns>
+        public bool ContainsAny(int startIndex, int endIndex)
+        {
+            foreach (var range in _list)
+            {
+                if (startIndex <= range.UpperBound && endIndex >= range.LowerBound)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Returns true if the given index is contained in the table with the the given value
         /// </summary>
         /// <param name="index">index to search for</param>


### PR DESCRIPTION
## PR Type

Bugfix

## What is the current behavior?

Only one range can be selected at a time, deselecting ranges is not implemented.

## What is the new behavior?

Ranges can be selected / deselected using mouse + ctrl + shift keys as in windows explorer.